### PR TITLE
Update to work with Jupyterlab > 3

### DIFF
--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -50,7 +50,7 @@ jobs:
         run: docker build . --file Dockerfile --tag $IMAGE_NAME
 
       - name: Log into GitHub Container Registry
-        run: echo "${{ secrets.CONTAINER_REGISTRY_GITHUB_TOKEN }}" | docker login https://ghcr.io -u ${{ github.actor }} --password-stdin
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login https://ghcr.io -u ${{ github.actor }} --password-stdin
 
       - name: Push image to GitHub Container Registry
         run: |
@@ -66,7 +66,7 @@ jobs:
           [[ "${{ github.ref }}" == "refs/tags/"* ]] && VERSION=$(echo $VERSION | sed -e 's/^v//')
 
           # Use Docker `latest` tag convention
-          [ "$VERSION" == "master" ] && VERSION=latest
+          [ "$VERSION" == "main" ] && VERSION=latest
 
           echo IMAGE_ID=$IMAGE_ID
           echo VERSION=$VERSION

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,6 +27,7 @@ RUN pip install --upgrade pip && \
     jupyterlab_latex \
     jupyterlab-drawio \
     jupyterlab-lsp \
+    'python-lsp-server[all]' \
     jupyterlab-git \
     jupyterlab-spreadsheet-editor \
     jupyter-dash

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,20 +17,20 @@ RUN apt-get update -y && \
 # Install packages and extensions for JupyterLab
 RUN pip install --upgrade pip && \
   pip install --upgrade \
-    jupyterlab>=2.0.0 \
+    jupyterlab>=3.0.0 \
     ipywidgets \
     jupyter-lsp \
     python-language-server \
     jupyterlab-git \
-    jupyter_bokeh
-#  jupyter labextension install \
-#    @jupyter-widgets/jupyterlab-manager \
-#    @jupyterlab/latex \
-#    jupyterlab-drawio \ 
-#    jupyterlab-plotly \
-#    @krassowski/jupyterlab-lsp \
-#    @jupyterlab/git \
-#    jupyterlab-spreadsheet 
+    jupyter_bokeh \
+    jupyterlab_widgets \
+    jupyterlab_latex \
+    jupyterlab-drawio \
+    jupyterlab-lsp \
+    jupyterlab-git \
+    jupyterlab-spreadsheet-editor \
+    jupyter-dash
+# from plotly documentation: install jupyter-dash
 
 # Install SPARQL kernel
 RUN pip install sparqlkernel

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,16 +21,16 @@ RUN pip install --upgrade pip && \
     ipywidgets \
     jupyter-lsp \
     python-language-server \
-    jupyterlab-git && \
-  jupyter labextension install \
-    @jupyter-widgets/jupyterlab-manager \
-    @jupyterlab/latex \
-    jupyterlab-drawio \ 
-    jupyterlab-plotly \
-    @bokeh/jupyter_bokeh \
-    @krassowski/jupyterlab-lsp \
-    @jupyterlab/git \
-    jupyterlab-spreadsheet 
+    jupyterlab-git \
+    jupyter_bokeh
+#  jupyter labextension install \
+#    @jupyter-widgets/jupyterlab-manager \
+#    @jupyterlab/latex \
+#    jupyterlab-drawio \ 
+#    jupyterlab-plotly \
+#    @krassowski/jupyterlab-lsp \
+#    @jupyterlab/git \
+#    jupyterlab-spreadsheet 
 
 # Install SPARQL kernel
 RUN pip install sparqlkernel

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.8
+FROM python:3.10
 
 # Install nicer Bash terminal
 RUN git clone --depth=1 https://github.com/Bash-it/bash-it.git ~/.bash_it && \

--- a/README.md
+++ b/README.md
@@ -91,5 +91,7 @@ services:
 Clone the repository, then build the container image:
 
 ```bash
+git clone https://github.com/ptr33/Jupyterlab.git
+cd Jupyterlab
 docker build -t ghcr.io/ptr33/jupyterlab .
 ```

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 #### Installed kernels
 
-* Python 3.8 with autocomplete and suggestions ([LSP](https://github.com/krassowski/jupyterlab-lsp))
+* Python 3.10 with autocomplete and suggestions ([LSP](https://github.com/krassowski/jupyterlab-lsp))
 * [IJava](https://github.com/SpencerPark/IJava)
 * [SPARQL kernel](https://github.com/paulovn/sparql-kernel)
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://github.com/amalic/Jupyterlab/blob/master/LICENSE)
-[![Publish Docker image](https://github.com/vemonet/Jupyterlab/workflows/Publish%20Docker%20image/badge.svg)](https://github.com/users/vemonet/packages/container/package/jupyterlab)
+[![Publish Docker image](https://github.com/ptr33/Jupyterlab/workflows/Publish%20Docker%20image/badge.svg)](https://github.com/users/ptr33/packages/container/package/jupyterlab)
 
 
 ## Jupyterlab Docker container
@@ -37,17 +37,17 @@ The container will install requirements from files present in the `/notebooks` f
 
 ### Pull/Update to latest version
 ```bash
-docker pull ghcr.io/vemonet/jupyterlab:latest
+docker pull ghcr.io/ptr33/jupyterlab:latest
 ```
 
 ### Run
 ```bash
-docker run --rm -it -p 8888:8888 ghcr.io/vemonet/jupyterlab
+docker run --rm -it -p 8888:8888 ghcr.io/ptr33/jupyterlab
 ```
 
 or if you want to define your own password and shared volume:
 ```bash
-docker run --rm -it -p 8888:8888 -v $(pwd)/data:/notebooks -e PASSWORD="password" ghcr.io/vemonet/jupyterlab
+docker run --rm -it -p 8888:8888 -v $(pwd)/data:/notebooks -e PASSWORD="password" ghcr.io/ptr33/jupyterlab
 ```
 
 ### Run from Git repository
@@ -63,7 +63,7 @@ docker run --rm -it -p 8888:8888 -v /data/jupyterlab-notebooks:/notebooks -e PAS
 or use the current directory as source code in the container:
 
 ```bash
-docker run --rm -it -p 8888:8888 -v $(pwd):/notebooks -e PASSWORD="<your_secret>" ghcr.io/vemonet/jupyterlab:latest
+docker run --rm -it -p 8888:8888 -v $(pwd):/notebooks -e PASSWORD="<your_secret>" ghcr.io/ptr33/jupyterlab:latest
 ```
 
 > Use `${pwd}` for Windows
@@ -76,7 +76,7 @@ Add JupyterLab to a `docker-compose.yml` file:
 services:
   jupyterlab:
     container_name: jupyterlab
-    image: ghcr.io/vemonet/jupyterlab
+    image: ghcr.io/ptr33/jupyterlab
     ports:
       - 8888:8888
     volumes:
@@ -91,5 +91,5 @@ services:
 Clone the repository, then build the container image:
 
 ```bash
-docker build -t ghcr.io/vemonet/jupyterlab .
+docker build -t ghcr.io/ptr33/jupyterlab .
 ```


### PR DESCRIPTION
* Update jupyterlab extension to version 3 syntax
see https://issueexplorer.com/issue/bokeh/jupyter_bokeh/127
Starting with version 3.0 for Jupyterlab 3.0 we only support installing the pre-built extensions distributed by us as conda and pip packages.

* add python lsp server

* Corrected login and set main for latest repository

* Python to Version 3.10

* Update README.md