### PR TITLE
Update to work with Jupyterlab > 3

### DIFF
--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -50,7 +50,7 @@ jobs:
         run: docker build . --file Dockerfile --tag $IMAGE_NAME
 
       - name: Log into GitHub Container Registry
-        run: echo "${{ secrets.CONTAINER_REGISTRY_GITHUB_TOKEN }}" | docker login https://ghcr.io -u ${{ github.actor }} --password-stdin
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login https://ghcr.io -u ${{ github.actor }} --password-stdin
 
       - name: Push image to GitHub Container Registry
         run: |
@@ -66,7 +66,7 @@ jobs:
           [[ "${{ github.ref }}" == "refs/tags/"* ]] && VERSION=$(echo $VERSION | sed -e 's/^v//')
 
           # Use Docker `latest` tag convention
-          [ "$VERSION" == "master" ] && VERSION=latest
+          [ "$VERSION" == "main" ] && VERSION=latest
 
           echo IMAGE_ID=$IMAGE_ID
           echo VERSION=$VERSION

--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -15,9 +15,9 @@ on:
     # Publish `master` as Docker `latest` image.
     branches:
       - main
-  #   # Publish `v1.2.3` tags as release `1.2.3`.
-  #   tags:
-  #     - v*
+    # Publish `v1.2.3` tags as release `1.2.3`.
+    tags:
+      - v*
 
 jobs:
   # Test docker build before publishing

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,18 +25,16 @@ RUN pip install --upgrade pip && \
   pip install --upgrade \
     jupyterlab>=4.4.6 \
     ipywidgets \
-    jupyter-lsp \
-    python-language-server \
     jupyterlab-git \
     jupyter_bokeh \
     jupyterlab_widgets \
     jupyterlab_latex \
-    'python-lsp-server[all]' \
     jupyterlab-git \
+    jupyterlab-lsp \
+    jedi-language-server \
     jupyterlab-spreadsheet-editor \
     lckr-jupyterlab-variableinspector \
-    jupyterlab-filesystem-access \
-    jupyterlab-lsp
+    jupyterlab-filesystem-access
 
 # install python library
 COPY requirements.txt .
@@ -57,24 +55,3 @@ VOLUME /notebooks
 WORKDIR /notebooks
 ENTRYPOINT ["entrypoint.sh"]
 
-
-
-## Old pip install for data science:
-
-    # jedi==0.15.2 \ 
-    # # jupyterlab-lsp does not support 0.17
-    # jupyterlab_latex \
-    # plotly \
-    # bokeh \
-    # numpy \
-    # scipy \
-    # numexpr \
-    # patsy \
-    # scikit-learn \
-    # scikit-image \
-    # matplotlib \
-    # ipython \
-    # pandas \
-    # sympy \
-    # seaborn \
-    # nose \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,11 @@
-FROM python:3.11
+FROM python:3.13
 
 # Install nicer Bash terminal
 RUN git clone --depth=1 https://github.com/Bash-it/bash-it.git ~/.bash_it && \
   bash ~/.bash_it/install.sh --silent
 
-# Install NodeJS 18
-RUN curl -sL https://deb.nodesource.com/setup_18.x | bash - && \
+# Install NodeJS 22
+RUN curl -sL https://deb.nodesource.com/setup_22.x | bash - && \
   apt-get upgrade -y && \
   apt-get install -y nodejs texlive-latex-extra texlive-xetex && \
   rm -rf /var/lib/apt/lists/*
@@ -23,7 +23,7 @@ RUN cargo --help
 # Install packages and extensions for JupyterLab
 RUN pip install --upgrade pip && \
   pip install --upgrade \
-    jupyterlab>=3.0.0 \
+    jupyterlab>=4.4.6 \
     ipywidgets \
     jupyter-lsp \
     python-language-server \
@@ -31,14 +31,12 @@ RUN pip install --upgrade pip && \
     jupyter_bokeh \
     jupyterlab_widgets \
     jupyterlab_latex \
-    jupyterlab-drawio \
-    jupyterlab-lsp \
     'python-lsp-server[all]' \
     jupyterlab-git \
     jupyterlab-spreadsheet-editor \
-    jupyter-dash \
-    lckr-jupyterlab-variableinspector
-# from plotly documentation: install jupyter-dash
+    lckr-jupyterlab-variableinspector \
+    jupyterlab-filesystem-access \
+    jupyterlab-lsp
 
 # install python library
 COPY requirements.txt .
@@ -48,8 +46,7 @@ RUN pip3 install --upgrade pip && \
     apt-get update && \
     apt-get install -y pandoc
 
-RUN jupyter labextension install jupyterlab-filesystem-access && \
-    jupyter lab build
+RUN jupyter lab build
 
 COPY bin/entrypoint.sh /usr/local/bin/
 COPY config/jupyter_notebook_config.py /root/.jupyter/

--- a/Dockerfile
+++ b/Dockerfile
@@ -38,7 +38,8 @@ RUN pip3 install --upgrade pip && \
     apt-get update && \
     apt-get install -y pandoc
 
-RUN jupyter lab build 
+RUN jupyter labextension install jupyterlab-filesystem-access && \
+    jupyter lab build
 
 COPY bin/entrypoint.sh /usr/local/bin/
 COPY config/jupyter_notebook_config.py /root/.jupyter/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,24 @@
-FROM python:3.10
+FROM python:3.11
 
 # Install nicer Bash terminal
 RUN git clone --depth=1 https://github.com/Bash-it/bash-it.git ~/.bash_it && \
   bash ~/.bash_it/install.sh --silent
 
-# Install NodeJS 14
-RUN curl -sL https://deb.nodesource.com/setup_14.x | bash - && \
+# Install NodeJS 18
+RUN curl -sL https://deb.nodesource.com/setup_18.x | bash - && \
   apt-get upgrade -y && \
   apt-get install -y nodejs texlive-latex-extra texlive-xetex && \
   rm -rf /var/lib/apt/lists/*
+
+
+# install Rust (needed for y-py) - see https://rustup.rs/
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+
+# Add .cargo/bin to PATH
+ENV PATH="/root/.cargo/bin:${PATH}"
+
+# Check cargo is visible
+RUN cargo --help
 
 # Install packages and extensions for JupyterLab
 RUN pip install --upgrade pip && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,15 +4,11 @@ FROM python:3.10
 RUN git clone --depth=1 https://github.com/Bash-it/bash-it.git ~/.bash_it && \
   bash ~/.bash_it/install.sh --silent
 
-# Install NodeJS 12
-RUN curl -sL https://deb.nodesource.com/setup_12.x | bash - && \
+# Install NodeJS 14
+RUN curl -sL https://deb.nodesource.com/setup_14.x | bash - && \
   apt-get upgrade -y && \
   apt-get install -y nodejs texlive-latex-extra texlive-xetex && \
   rm -rf /var/lib/apt/lists/*
-
-# Install Java
-RUN apt-get update -y && \
-    apt-get install default-jdk -y
 
 # Install packages and extensions for JupyterLab
 RUN pip install --upgrade pip && \
@@ -34,30 +30,13 @@ RUN pip install --upgrade pip && \
     lckr-jupyterlab-variableinspector
 # from plotly documentation: install jupyter-dash
 
-# Install SPARQL kernel
-RUN pip install sparqlkernel
-RUN jupyter sparqlkernel install 
-
-# Install IJava kernel
-RUN curl -L https://github.com/SpencerPark/IJava/releases/download/v1.3.0/ijava-1.3.0.zip > ijava-kernel.zip
-RUN unzip ijava-kernel.zip -d ijava-kernel \
-  && cd ijava-kernel \
-  && python3 install.py --sys-prefix
-
-# Install jupyter RISE extension (for IJava)
-RUN pip install jupyter_contrib-nbextensions RISE \
-  && jupyter-nbextension install rise --py --system \
-  && jupyter-nbextension enable rise --py --system \
-  && jupyter contrib nbextension install --system \
-  && jupyter nbextension enable hide_input/main
-RUN rm ijava-kernel.zip
-RUN rm -rf ijava-kernel
-
 # install python library
 COPY requirements.txt .
 RUN pip3 install --upgrade pip && \
     pip3 install --no-cache-dir -r requirements.txt \
-    && rm -rf ~/.cache/pip
+    && rm -rf ~/.cache/pip && \
+    apt-get update && \
+    apt-get install -y pandoc
 
 RUN jupyter lab build 
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -52,12 +52,17 @@ RUN pip install jupyter_contrib-nbextensions RISE \
 RUN rm ijava-kernel.zip
 RUN rm -rf ijava-kernel
 
+# install python library
+COPY requirements.txt .
+RUN pip3 install --upgrade pip && \
+    pip3 install --no-cache-dir -r requirements.txt \
+    && rm -rf ~/.cache/pip
+
 RUN jupyter lab build 
 
 COPY bin/entrypoint.sh /usr/local/bin/
 COPY config/jupyter_notebook_config.py /root/.jupyter/
 # COPY config/ /root/.jupyter/
-
 
 EXPOSE 8888
 VOLUME /notebooks

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.8
+FROM python:3.10
 
 # Install nicer Bash terminal
 RUN git clone --depth=1 https://github.com/Bash-it/bash-it.git ~/.bash_it && \
@@ -17,20 +17,21 @@ RUN apt-get update -y && \
 # Install packages and extensions for JupyterLab
 RUN pip install --upgrade pip && \
   pip install --upgrade \
-    jupyterlab>=2.0.0 \
+    jupyterlab>=3.0.0 \
     ipywidgets \
     jupyter-lsp \
     python-language-server \
-    jupyterlab-git && \
-  jupyter labextension install \
-    @jupyter-widgets/jupyterlab-manager \
-    @jupyterlab/latex \
-    jupyterlab-drawio \ 
-    jupyterlab-plotly \
-    @bokeh/jupyter_bokeh \
-    @krassowski/jupyterlab-lsp \
-    @jupyterlab/git \
-    jupyterlab-spreadsheet 
+    jupyterlab-git \
+    jupyter_bokeh \
+    jupyterlab_widgets \
+    jupyterlab_latex \
+    jupyterlab-drawio \
+    jupyterlab-lsp \
+    'python-lsp-server[all]' \
+    jupyterlab-git \
+    jupyterlab-spreadsheet-editor \
+    jupyter-dash
+# from plotly documentation: install jupyter-dash
 
 # Install SPARQL kernel
 RUN pip install sparqlkernel

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,8 @@ RUN pip install --upgrade pip && \
     'python-lsp-server[all]' \
     jupyterlab-git \
     jupyterlab-spreadsheet-editor \
-    jupyter-dash
+    jupyter-dash \
+    lckr-jupyterlab-variableinspector
 # from plotly documentation: install jupyter-dash
 
 # Install SPARQL kernel

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.13
+FROM python:3.14
 
 # Install nicer Bash terminal
 RUN git clone --depth=1 https://github.com/Bash-it/bash-it.git ~/.bash_it && \

--- a/README.md
+++ b/README.md
@@ -12,9 +12,10 @@ Changed base url to make operation behind appache reverse proxy easier: http://l
 
 #### Installed kernels
 
-* Python 3.11 with autocomplete and suggestions ([LSP](https://github.com/krassowski/jupyterlab-lsp))
+* Python 3.13 with autocomplete and suggestions ([LSP](https://github.com/krassowski/jupyterlab-lsp))
 
 #### Installed Jupyterlab extensions
+- Jupyterlab 4.4.6
 - [Jupyter Widgets](https://ipywidgets.readthedocs.io/en/latest/examples/Widget%20Basics.html)
 - [@jupyterlab/git](https://www.npmjs.com/package/@jupyterlab/git)
 - [@krassowski/jupyterlab-lsp](https://github.com/krassowski/jupyterlab-lsp)

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Changed base url to make operation behind appache reverse proxy easier: http://l
 
 #### Installed kernels
 
-* Python 3.10 with autocomplete and suggestions ([LSP](https://github.com/krassowski/jupyterlab-lsp))
+* Python 3.11 with autocomplete and suggestions ([LSP](https://github.com/krassowski/jupyterlab-lsp))
 
 #### Installed Jupyterlab extensions
 - [Jupyter Widgets](https://ipywidgets.readthedocs.io/en/latest/examples/Widget%20Basics.html)

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://github.com/amalic/Jupyterlab/blob/master/LICENSE)
-[![Publish Docker image](https://github.com/vemonet/Jupyterlab/workflows/Publish%20Docker%20image/badge.svg)](https://github.com/users/vemonet/packages/container/package/jupyterlab)
+[![Publish Docker image](https://github.com/ptr33/Jupyterlab/workflows/Publish%20Docker%20image/badge.svg)](https://github.com/users/ptr33/packages/container/package/jupyterlab)
 
 
 ## Jupyterlab Docker container
@@ -8,7 +8,7 @@
 
 #### Installed kernels
 
-* Python 3.8 with autocomplete and suggestions ([LSP](https://github.com/krassowski/jupyterlab-lsp))
+* Python 3.10 with autocomplete and suggestions ([LSP](https://github.com/krassowski/jupyterlab-lsp))
 * [IJava](https://github.com/SpencerPark/IJava)
 * [SPARQL kernel](https://github.com/paulovn/sparql-kernel)
 
@@ -37,17 +37,17 @@ The container will install requirements from files present in the `/notebooks` f
 
 ### Pull/Update to latest version
 ```bash
-docker pull ghcr.io/vemonet/jupyterlab:latest
+docker pull ghcr.io/ptr33/jupyterlab:latest
 ```
 
 ### Run
 ```bash
-docker run --rm -it -p 8888:8888 ghcr.io/vemonet/jupyterlab
+docker run --rm -it -p 8888:8888 ghcr.io/ptr33/jupyterlab
 ```
 
 or if you want to define your own password and shared volume:
 ```bash
-docker run --rm -it -p 8888:8888 -v $(pwd)/data:/notebooks -e PASSWORD="password" ghcr.io/vemonet/jupyterlab
+docker run --rm -it -p 8888:8888 -v $(pwd)/data:/notebooks -e PASSWORD="password" ghcr.io/ptr33/jupyterlab
 ```
 
 ### Run from Git repository
@@ -63,7 +63,7 @@ docker run --rm -it -p 8888:8888 -v /data/jupyterlab-notebooks:/notebooks -e PAS
 or use the current directory as source code in the container:
 
 ```bash
-docker run --rm -it -p 8888:8888 -v $(pwd):/notebooks -e PASSWORD="<your_secret>" ghcr.io/vemonet/jupyterlab:latest
+docker run --rm -it -p 8888:8888 -v $(pwd):/notebooks -e PASSWORD="<your_secret>" ghcr.io/ptr33/jupyterlab:latest
 ```
 
 > Use `${pwd}` for Windows
@@ -76,7 +76,7 @@ Add JupyterLab to a `docker-compose.yml` file:
 services:
   jupyterlab:
     container_name: jupyterlab
-    image: ghcr.io/vemonet/jupyterlab
+    image: ghcr.io/ptr33/jupyterlab
     ports:
       - 8888:8888
     volumes:
@@ -91,5 +91,7 @@ services:
 Clone the repository, then build the container image:
 
 ```bash
-docker build -t ghcr.io/vemonet/jupyterlab .
+git clone https://github.com/ptr33/Jupyterlab.git
+cd Jupyterlab
+docker build -t ghcr.io/ptr33/jupyterlab .
 ```

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Changed base url to make operation behind appache reverse proxy easier: http://l
 - [@bokeh/jupyter_bokeh](https://github.com/bokeh/jupyter_bokeh)
 - [@jupyterlab/toc](https://www.npmjs.com/package/@jupyterlab/toc)
 - [lckr-jupyterlab-variableinspector](https://github.com/lckr/jupyterlab-variableInspector)
+- [jupyterlab-filesystem-access](https://github.com/jupyterlab-contrib/jupyterlab-filesystem-access)
 
 ### Your notebooks
 

--- a/README.md
+++ b/README.md
@@ -18,10 +18,9 @@ Changed base url to make operation behind appache reverse proxy easier: http://l
 - Jupyterlab 4.4.6
 - [Jupyter Widgets](https://ipywidgets.readthedocs.io/en/latest/examples/Widget%20Basics.html)
 - [@jupyterlab/git](https://www.npmjs.com/package/@jupyterlab/git)
-- [@krassowski/jupyterlab-lsp](https://github.com/krassowski/jupyterlab-lsp)
+- jedi-language-server
 - [@jupyterlab/latex](https://github.com/jupyterlab/jupyterlab-latex)
 - [jupyterlab-plotly](https://www.npmjs.com/package/jupyterlab-plotly)
-- [jupyterlab-drawio](https://github.com/QuantStack/jupyterlab-drawio)
 - [jupyterlab-spreadsheet](https://github.com/quigleyj97/jupyterlab-spreadsheet)
 - [@bokeh/jupyter_bokeh](https://github.com/bokeh/jupyter_bokeh)
 - [@jupyterlab/toc](https://www.npmjs.com/package/@jupyterlab/toc)

--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@
 
 Additional packages can be installed on creation of container by adding to requirements.txt.
 
+Changed base url to make operation behind appache reverse proxy easier: http://localhost:8888/jupyter
+
 #### Installed kernels
 
 * Python 3.10 with autocomplete and suggestions ([LSP](https://github.com/krassowski/jupyterlab-lsp))
@@ -59,7 +61,7 @@ You can provide a Git repository to be cloned in `/notebooks` when starting the 
 docker run --rm -it -p 8888:8888 -v /data/jupyterlab-notebooks:/notebooks -e PASSWORD="<your_secret>" -e GIT_URL="https://github.com/vemonet/translator-sparql-notebook" ghcr.io/ptr33/jupyterlab:latest
 ```
 
-> Access on http://localhost:8888 and files shared in `/data/jupyterlab-notebooks`
+> Access on http://localhost:8888/jupyter and files shared in `/data/jupyterlab-notebooks`
 
 or use the current directory as source code in the container:
 

--- a/README.md
+++ b/README.md
@@ -11,8 +11,6 @@ Additional packages can be installed on creation of container by adding to requi
 #### Installed kernels
 
 * Python 3.10 with autocomplete and suggestions ([LSP](https://github.com/krassowski/jupyterlab-lsp))
-* [IJava](https://github.com/SpencerPark/IJava)
-* [SPARQL kernel](https://github.com/paulovn/sparql-kernel)
 
 #### Installed Jupyterlab extensions
 - [Jupyter Widgets](https://ipywidgets.readthedocs.io/en/latest/examples/Widget%20Basics.html)
@@ -58,7 +56,7 @@ docker run --rm -it -p 8888:8888 -v $(pwd)/data:/notebooks -e PASSWORD="password
 You can provide a Git repository to be cloned in `/notebooks` when starting the container (it will automatically install packages if `requirements.txt`, `packages.txt` or `extensions.txt` are present at the root of the repository).
 
 ```bash
-docker run --rm -it -p 8888:8888 -v /data/jupyterlab-notebooks:/notebooks -e PASSWORD="<your_secret>" -e GIT_URL="https://github.com/vemonet/translator-sparql-notebook" ghcr.io/vemonet/jupyterlab:latest
+docker run --rm -it -p 8888:8888 -v /data/jupyterlab-notebooks:/notebooks -e PASSWORD="<your_secret>" -e GIT_URL="https://github.com/vemonet/translator-sparql-notebook" ghcr.io/ptr33/jupyterlab:latest
 ```
 
 > Access on http://localhost:8888 and files shared in `/data/jupyterlab-notebooks`

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@
 
 **This Docker container runs as root user!** It can be helpful when e.g. the popular jupyter/datascience-notebook image does not work because it runs as Jovyan user. 
 
+Additional packages can be installed on creation of container by adding to requirements.txt.
+
 #### Installed kernels
 
 * Python 3.10 with autocomplete and suggestions ([LSP](https://github.com/krassowski/jupyterlab-lsp))

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Additional packages can be installed on creation of container by adding to requi
 - [jupyterlab-spreadsheet](https://github.com/quigleyj97/jupyterlab-spreadsheet)
 - [@bokeh/jupyter_bokeh](https://github.com/bokeh/jupyter_bokeh)
 - [@jupyterlab/toc](https://www.npmjs.com/package/@jupyterlab/toc)
+- [lckr-jupyterlab-variableinspector](https://github.com/lckr/jupyterlab-variableInspector)
 
 ### Your notebooks
 

--- a/README.md
+++ b/README.md
@@ -12,10 +12,10 @@ Changed base url to make operation behind appache reverse proxy easier: http://l
 
 #### Installed kernels
 
-* Python 3.13 with autocomplete and suggestions ([LSP](https://github.com/krassowski/jupyterlab-lsp))
+* Python **3.14** with autocomplete and suggestions ([LSP](https://github.com/krassowski/jupyterlab-lsp))
 
 #### Installed Jupyterlab extensions
-- Jupyterlab 4.4.6
+- Jupyterlab 4.5.6
 - [Jupyter Widgets](https://ipywidgets.readthedocs.io/en/latest/examples/Widget%20Basics.html)
 - [@jupyterlab/git](https://www.npmjs.com/package/@jupyterlab/git)
 - jedi-language-server

--- a/bin/entrypoint.sh
+++ b/bin/entrypoint.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-CMD="jupyter lab --allow-root --ip=0.0.0.0 --no-browser"
+CMD="jupyter lab --allow-root --ip=0.0.0.0 --no-browser --ServerApp.base_url=/jupyter"
 
 if [[ -v PASSWORD ]]; then
   PASSWORD=$(python -c "import IPython; print(IPython.lib.security.passwd('$PASSWORD'))")

--- a/build
+++ b/build
@@ -1,0 +1,5 @@
+#!/bin/bash
+BRANCH=`git branch --show-current`
+if [ $BRANCH = "main" ]; then BRANCH="latest"; fi
+docker build . -t ghcr.io/ptr33/jupyterlab:$BRANCH   && \
+docker push ghcr.io/ptr33/jupyterlab:$BRANCH

--- a/config/jupyter_notebook_config.py
+++ b/config/jupyter_notebook_config.py
@@ -88,7 +88,7 @@ c.NotebookApp.terminado_settings = {'shell_command': ['/bin/bash']}
 ## The base URL for the notebook server.
 #  
 #  Leading and trailing slashes can be omitted, and will automatically be added.
-#c.NotebookApp.base_url = '/'
+c.NotebookApp.base_url = '/jupyter'
 
 ## Specify what command to use to invoke a web browser when opening the notebook.
 #  If not specified, the default browser will be determined by the `webbrowser`

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,12 @@
+# List all packages here, which should be included in the container during build time
+numpy
+pandas
+matplotlib
+seaborn
+scipy
+# for %matplotlib widget to work install following:
+ipympl
+# scikit-learn
+# lightgbm
+# xgboost
+# keras

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,6 @@ ipympl
 # lightgbm
 # xgboost
 # keras
+# for exporting html files without code
+jupyterlab-nbconvert-nocode
+


### PR DESCRIPTION
Update jupyterlab extension to version 3 syntax
see https://issueexplorer.com/issue/bokeh/jupyter_bokeh/127
Starting with version 3.0 for Jupyterlab 3.0 we only support installing the pre-built extensions distributed by us as conda and pip packages.

add python lsp server

Corrected login and set main for latest repository

Python to Version 3.10

Update README.md
